### PR TITLE
fix(index): make sure all notifications are sent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ module.exports = function runRSSOBotDaemon (state) {
   const notify = Notify(state.get('configuration'))
   poller(state)
     .do(({ blogTitle, link, title }) => { H.log(`New URL in "${blogTitle}": "${link}"`) })
-    .switchMap(({ blogTitle, link, title }) => notify(blogTitle, link, title).retry(2))
+    .flatMap(({ blogTitle, link, title }) => notify(blogTitle, link, title).retry(2))
     .do(() => debug('Sent notifications'))
     /* Restart on error */
     .catch(err => {

--- a/src/lib/notify.js
+++ b/src/lib/notify.js
@@ -18,7 +18,7 @@ module.exports = config => {
   return (blog, link, title) =>
     /* Call all registered notifiers */
     O.merge(...notifierFunctions)
-      .switchMap(f => f(blog, link, title))
+      .flatMap(f => f(blog, link, title))
       /* The results should be ignored here */
       .toArray()
       .concatMap(results =>


### PR DESCRIPTION
If there is new observables switchMap cancels the old ones.
It can cancel notifications if the notifier module is slow to execute