### PR TITLE
fix(helpers): transformFilter returning incorrect 'kind'

### DIFF
--- a/src/lib/shared/helpers.js
+++ b/src/lib/shared/helpers.js
@@ -90,8 +90,8 @@ const Helpers = {
   transformFilter (filter) {
     return (
       filter[0] === '!'
-        ? {keyword: filter.substr(1), kind: false}
-        : {keyword: filter, kind: true}
+        ? {keyword: filter.substr(1), kind: true}
+        : {keyword: filter, kind: false}
     )
   },
 
@@ -268,8 +268,8 @@ const Helpers = {
       filters: () =>
         filters.map(f =>
           f.get('kind')
-            ? f.get('keyword')
-            : `!${f.get('keyword')}`
+            ? `!${f.get('keyword')}`
+            : f.get('keyword')
         ).join(', '),
       lastCheck: t => Helpers.parseTime(t).toISOString()
     })

--- a/tests/src/acceptance/index.js
+++ b/tests/src/acceptance/index.js
@@ -60,7 +60,7 @@ test.cb('test-config false', T.run(['test-config', `--config=${__dirname}/../../
 
 ; (() => {
   const url = 'https://lucaschmid.net/feed/rss.xml'
-  const filter = 'somefilter'
+  const filter = 'javascript'
   test.cb('add', T.run(['add', url, filter, '--no-wrap'], 4)((t, o, config) =>
     o.map(feed => {
       t.truthy(feed.includes('Luca Nils Schmid - Blog'))


### PR DESCRIPTION
The filters were not working properly, notifications were sent for the wrong RSS items.
According to the tests in "src/unit/poll.js", 'kind' should be inverted to work properly.

The "acceptance › index › add" test doesn't pass because the feed is empty because of the filter.  If it's empty, the display :
![image](https://user-images.githubusercontent.com/9142557/29845532-78a03e92-8d13-11e7-9c88-a02e5b0b8141.png)
 cannot be shown and the test fails trying to compare it.
